### PR TITLE
readme: npm needs 'run' for named scripts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ cd angular2-express-starter
 npm install && npm run typings
 
 # start server
-npm develop
+npm run develop
 
 # Applciation url: http://localhost:3000
 ```


### PR DESCRIPTION
additional suggestions (not in the pull request)
- no mention of the required step to "node copy.js" (or should npm develop take care?)
- depending on the mileage of the audience: it might be surprising that "npm install", but surely "npm run typings" requires a live internet connection?
